### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+engauge-digitizer (12.1+ds.1-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 23 Jun 2021 02:28:16 -0000
+
 engauge-digitizer (12.1+ds.1-1) unstable; urgency=medium
 
   * New upstream release. Closes: #974131

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 engauge-digitizer (12.1+ds.1-2) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit.
+  * Update standards version to 4.5.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 23 Jun 2021 02:28:16 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: science
 Priority: optional
 Maintainer: Tobias Winchen <tobias@winchen.de>
 Build-Depends: dpkg-dev (>= 1.16.1~), debhelper (>= 13), debhelper-compat (= 13), qtbase5-dev, qtbase5-dev-tools, qttools5-dev, qttools5-dev-tools, libqt5sql5-sqlite, libfftw3-dev, libjpeg-dev, liblog4cpp5-dev, libopenjp2-7-dev, libpoppler-qt5-dev
-Standards-Version: 4.4.0
+Standards-Version: 4.5.1
 Vcs-Git: https://github.com/TobiasWinchen/engauge_debian.git
 Vcs-Browser: https://github.com/winchen/engauge_debian
 Homepage: https://markummitchell.github.io/engauge-digitizer

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,3 @@
+---
+Bug-Database: https://github.com/markummitchell/engauge-digitizer/issues
+Bug-Submit: https://github.com/markummitchell/engauge-digitizer/issues/new


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Bug-Database, Bug-Submit. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))

* Update standards version to 4.5.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/engauge-digitizer/babd1505-a7c0-4b24-8d24-9d64b2723839.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/f2/0ea4a926da20e5c9f53fc3492ca9c226e04f12.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/76/b5656b00c42665b3cec38816786fa696a3b716.debug

No differences were encountered between the control files of package \*\*engauge-digitizer\*\*
### Control files of package engauge-digitizer-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-76b5656b00c42665b3cec38816786fa696a3b716-] {+f20ea4a926da20e5c9f53fc3492ca9c226e04f12+}

No differences were encountered between the control files of package \*\*engauge-digitizer-doc\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/babd1505-a7c0-4b24-8d24-9d64b2723839/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/babd1505-a7c0-4b24-8d24-9d64b2723839/diffoscope)).
