### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ engauge-digitizer (12.1+ds.1-2) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit.
   * Update standards version to 4.5.1, no changes needed.
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on dpkg-dev.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 23 Jun 2021 02:28:16 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: engauge-digitizer
 Section: science
 Priority: optional
 Maintainer: Tobias Winchen <tobias@winchen.de>
-Build-Depends: dpkg-dev (>= 1.16.1~), debhelper (>= 13), debhelper-compat (= 13), qtbase5-dev, qtbase5-dev-tools, qttools5-dev, qttools5-dev-tools, libqt5sql5-sqlite, libfftw3-dev, libjpeg-dev, liblog4cpp5-dev, libopenjp2-7-dev, libpoppler-qt5-dev
+Build-Depends: debhelper (>= 13), debhelper-compat (= 13), qtbase5-dev, qtbase5-dev-tools, qttools5-dev, qttools5-dev-tools, libqt5sql5-sqlite, libfftw3-dev, libjpeg-dev, liblog4cpp5-dev, libopenjp2-7-dev, libpoppler-qt5-dev
 Standards-Version: 4.5.1
 Vcs-Git: https://github.com/TobiasWinchen/engauge_debian.git
 Vcs-Browser: https://github.com/winchen/engauge_debian


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/engauge-digitizer/5e2457fb-3163-4293-b6ef-d5aec5275453.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/24/27e6b99b13b9830af64655bfaef969da7e75a2.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/fe/6661531235fa4e0d371a828a0cd919bb9d0fe8.debug

No differences were encountered between the control files of package \*\*engauge-digitizer\*\*
### Control files of package engauge-digitizer-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-fe6661531235fa4e0d371a828a0cd919bb9d0fe8-] {+2427e6b99b13b9830af64655bfaef969da7e75a2+}

No differences were encountered between the control files of package \*\*engauge-digitizer-doc\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/5e2457fb-3163-4293-b6ef-d5aec5275453/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/5e2457fb-3163-4293-b6ef-d5aec5275453/diffoscope)).
